### PR TITLE
Remove extraneous push in Release task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,10 +40,9 @@ task :release do
   Rake::Task["workarea:changelog"].execute
   system "git add CHANGELOG.md"
   system "git commit -m 'Update CHANGELOG'"
-  system "git push origin HEAD"
 
   system "git tag -a v#{Workarea::OneTheme::VERSION} -m 'Tagging #{Workarea::OneTheme::VERSION}'"
-  system "git push --tags"
+  system "git push origin HEAD --follow-tags"
 
   system "gem build workarea-one_theme.gemspec"
   system "gem push workarea-one_theme-#{Workarea::OneTheme::VERSION}.gem"


### PR DESCRIPTION
We're running out of minutes in our GitHub actions due to duplicate pushes
during a release. This consolidates the two pushes into one.

No changelog

WORKAREA-148